### PR TITLE
Htmx v1.9.6

### DIFF
--- a/samples/HelloWorld/Program.fs
+++ b/samples/HelloWorld/Program.fs
@@ -46,7 +46,7 @@ let handleHtml : HttpHandler =
         Templates.html5 "en"
             [
                 Elem.link [ Attr.href "style.css"; Attr.rel "stylesheet" ]
-                Elem.script [ Attr.src "https://unpkg.com/htmx.org@1.8.0"] []
+                Elem.script [ Attr.src Script.src ] []
             ]
             [
                 Elem.h1 [] [

--- a/src/Falco.Htmx/Extensions.fs
+++ b/src/Falco.Htmx/Extensions.fs
@@ -120,3 +120,8 @@ module Response =
     // Allows you to trigger client side events, see the documentation for more info
     let withHxTriggerAfterSwap : HttpResponseModifier =
         Response.withHeaders [ "HX-Trigger-After-Swap", _trueValue ]
+
+    /// A CSS selector that allows you to choose which part of the response is used to be swapped in.
+    /// see the documentation for more info
+    let withHxReselect (selector: string) : HttpResponseModifier =
+        Response.withHeaders [ "HX-Reselect", selector ]

--- a/src/Falco.Htmx/Extensions.fs
+++ b/src/Falco.Htmx/Extensions.fs
@@ -22,6 +22,11 @@ type HtmxRequestHeaders =
       /// The id of the triggered element if it exists
       HxTrigger : string option }
 
+/// Value for the HX-Trigger Response Header
+type HxTriggerResponse =
+    | Events of string list
+    | DetailedEvents of (string * obj) list
+
 [<RequireQualifiedAccess>]
 module Request =
     let getHtmxHeaders (ctx : HttpContext) : HtmxRequestHeaders =
@@ -100,16 +105,14 @@ module Response =
         Response.withHeaders [ "HX-Retarget", TargetOption.AsString option ]
 
     // Allows you to trigger client side events, see the documentation for more info
-    let withHxTrigger<'T>(event: string, detail : 'T option) : HttpResponseModifier =
+    let withHxTrigger<'T>(triggerResponse: HxTriggerResponse) : HttpResponseModifier =
         let headerValue =
-            match detail with
-            | Some detail' ->
-                [ event, detail ]
+            match triggerResponse with
+            | Events events -> events |> String.concat ", "
+            | DetailedEvents events ->
+                events
                 |> Map.ofList
                 |> fun x -> JsonSerializer.Serialize(x, Json.defaultSerializerOptions)
-
-            | None ->
-                event
 
         Response.withHeaders [ "HX-Trigger", headerValue ]
 

--- a/src/Falco.Htmx/Htmx.fs
+++ b/src/Falco.Htmx/Htmx.fs
@@ -201,3 +201,7 @@ type DisinheritOption =
         | AllAttributes -> "*"
         | ExcludeAttributes [] -> "*"
         | ExcludeAttributes names -> String.Join(" ", names)
+
+module Script =
+    /// The script of the version of HTMX this library is written for.
+    let src = "https://unpkg.com/htmx.org@1.9.6"

--- a/src/Falco.Htmx/Hx.fs
+++ b/src/Falco.Htmx/Hx.fs
@@ -205,11 +205,11 @@ let sync (targetOption : TargetOption, syncOption : SyncOption option) =
 /// Whether to force elements to validate themselves before a request
 let validate (value: bool) = Attr.create "hx-validate" (string value)
 
-/// Whether to prevent sensitive data being saved to the history cache
+/// Whether to save sensitive data to the history cache
 let history (value: bool) = Attr.create "hx-history" (string value)
 
 /// Handle any event with a script inline
-let on eventName script = Attr.create $"hx-on:{eventName}"
+let on eventName = Attr.create $"hx-on:{eventName}"
 
 /// adds the `disabled` attribute to the specified elements while a request is in flight
 let disabledElement (targetOption: TargetOption) =

--- a/src/Falco.Htmx/Hx.fs
+++ b/src/Falco.Htmx/Hx.fs
@@ -201,3 +201,16 @@ let sync (targetOption : TargetOption, syncOption : SyncOption option) =
         | None -> target'
 
     Attr.create "hx-sync" attrValue
+
+/// Whether to force elements to validate themselves before a request
+let validate (value: bool) = Attr.create "hx-validate" (string value)
+
+/// Whether to prevent sensitive data being saved to the history cache
+let history (value: bool) = Attr.create "hx-history" (string value)
+
+/// Handle any event with a script inline
+let on eventName script = Attr.create $"hx-on:{eventName}"
+
+/// adds the `disabled` attribute to the specified elements while a request is in flight
+let disabledElement (targetOption: TargetOption) =
+    Attr.create "hx-disabled-elt" (TargetOption.AsString targetOption)


### PR DESCRIPTION
Begin work on update to Htmx v1.9.6 (reference: #2)

HTMX Changelog - https://github.com/bigskysoftware/htmx/blob/master/CHANGELOG.md
Current Version - 1.8.0
New Version - 1.9.6

Attributes added:
- [x] hx-validate
- [x] hx-history
- [x] hx-on
- [x] hx-disabled-elt

Headers added or updated:
- [x] HX-Reselect response header
- [x] HX-Trigger header supports comma-separated event names

I may have missed a few things and some of these constructs may benefit from stronger typing. Will edit after reviews and re-reading the changelogs.